### PR TITLE
Add multi language support for README

### DIFF
--- a/README.ko.md
+++ b/README.ko.md
@@ -1,0 +1,249 @@
+# GravitaMaze (중력 미로)
+
+[![en](https://img.shields.io/badge/lang-en-red.svg)](https://github.com/salt26/gravita-maze/blob/main/README.md)
+[![ko](https://img.shields.io/badge/lang-ko-blue.svg)](https://github.com/salt26/gravita-maze/blob/main/README.ko.md)
+[![Version badge](https://img.shields.io/badge/Version-1.4.1-purple.svg)](https://github.com/salt26/gravita-maze/releases/tag/v1.4.1)  
+[![Licence](https://img.shields.io/badge/License-MIT-green.svg)](./LICENSE)  
+![Unity](https://img.shields.io/badge/unity-%23000000.svg?style=for-the-badge&logo=unity&logoColor=white)  
+![GitHub Actions](https://img.shields.io/badge/github%20actions-%232671E5.svg?style=for-the-badge&logo=githubactions&logoColor=white)
+
+## 게임 소개
+
+* 퍼즐 게임
+  * 중력을 조작해서 공을 미로에서 탈출시켜 보세요!
+* 영어 및 한국어 지원!
+
+### 다운로드
+
+#### [v1.4.1 for Android, Windows, and macOS](https://github.com/salt26/gravita-maze/releases/tag/v1.4.1)
+
+<details>
+<summary>여기를 클릭하면 과거 업데이트 내용을 표시하거나 숨길 수 있습니다.</summary>
+
+### 업데이트 (v1.3.1 -> v1.4.0)
+
+#### 사운드
+
+* 다양한 효과음 추가
+* Editor scene에 배경음 추가
+
+#### 첫 플레이 유저를 위한 개선 사항
+
+* 앱을 설치한 후 튜토리얼을 바로 플레이할 수 있도록 첫 플레이 유저 scene을 추가
+  * 튜토리얼 스킵도 가능함.
+* 자세한 튜토리얼 툴팁 제공.
+* 튜토리얼 맵 수정.
+
+#### 신규 모드 추가
+
+* Custom 모드 추가
+  * 플레이하고 싶은 맵을 선택하여 플레이 가능
+  * 커스텀 맵을 플레이하기 위해서 Editor 모드에 진입할 필요가 없어졌습니다.
+  * 각 맵에 대해서, 해당 맵을 클리어하기까지의 시도 횟수를 기록하고 반영구적으로 저장함.
+* Training 모드 추가
+  * 기믹의 종류별로 분류된 맵을 연습할 수 있습니다.
+  * 각 맵에 대해서, 해당 맵을 클리어하기까지의 시도 횟수를 기록하고 반영구적으로 저장함.
+* 크레딧 scene 추가
+
+#### 성취감 및 동기 부여
+
+* Tutorial과 Adventure 모드에서 표시되는 결과 UI에 애니메이션과 SFX를 추가하고 재구성함.
+* 시스템 추가
+  * 튜토리얼을 클리어하면 별 3개를 받습니다.
+  * Adventure 레벨을 클리어하면, 남은 목숨의 수에 따라 별을 받습니다.
+  * 모드 선택 및 Adventure 레벨 선택 scene에서, 각 레벨에서 획득한 별의 개수를 확인할 수 있습니다. 앱을 재시작하거나 업데이트하더라도 유지됩니다.
+* Adventure 모드에 다양한 맵 추가
+  * 이전보다 더욱 다양한 맵을 경험할 수 있습니다.
+  * 반복 플레이 주기를 더욱 늘려줍니다.
+* Custom 모드에 'God' 난이도 추가
+  * 난이도 기준: 숙련된 플레이어가 클리어하기 위해 20-50번 시도해야 하는 맵
+* 새로운 맵 추가 및 맵 난이도 밸런스 조정
+
+#### 편의 기능 및 사용자 경험 개선
+
+* 중력 조작 버튼 4개의 크기 확대.
+* 쇳덩이 안의 폰트를 밝은 색으로 변경.
+* 모드 선택 및 Adventure 레벨 선택 scene에서, 맵의 위치를 재배치해서 재시도 버튼을 누를 필요가 없도록 변경함.
+* Tutorial, Adventure, Custom, Traning 모드에서 게임을 일시정지할 때 표시되는 메뉴 UI를 재배치함.
+  * 일시정지 메뉴에서 배경음 및 효과음 음량을 조절 가능.
+  * 일시정지 메뉴에서 맵을 스킵(남은 시간을 0으로 변경)할 수 있음.
+* Custom 모드에서 난이도별로 폴더가 오름차순으로 정렬되도록 폴더명 변경.
+* 포털 애니메이션 추가 및 이미지 변경.
+
+### 업데이트 (v1.3.0 -> v1.3.1)
+
+#### 공통
+
+* Game Play 모드
+  * 공이 죽거나 재도전 버튼을 누르면 시간이 멈춤. 중력 조작 버튼을 누르면 다시 시간이 흐름.
+  * 시간이 멈추면 타이머 UI가 분홍색으로 변함. 시간이 다시 흐르면 보라색으로 변함.
+  * 공이 미로를 탈출하면, 중력에 의해 천천히 움직이는 애니메이션을 표시.
+* 게임 플레이 scene (Tutorial, Adventure, Editor 내 테스트 단계)에 신규 BGM 추가
+* Adventure 모드
+  * 대규모 맵 밸런스 패치 적용
+    * Easy: 맵 5개 업데이트, 각 맵의 시간 제한 변경.
+    * Normal: 맵 7개 업데이트.
+    * Hard: 맵 5개 업데이트.
+    * Insane: 맵 7개 업데이트.
+  * Adventure 모드에서 셔터가 포함된 맵도 등장합니다.
+* Editor 내에서, Adventure 모드에서는 등장하지 않는 신규 맵(셔터를 포함하는 맵)을 플레이 가능함
+  * Android 유저 분들은, `GravitaMaze.zip`을 다운로드한 후 "내 파일" 앱을 사용해서 루트 경로(`Internal storage`)에 압축 해제해주세요.
+  * macOS 유저 분들은, `GravitaMaze.zip`을 다운로드한 후, 압축 해제해서 `Maps` 폴더를 `GravitaMaze.app`의 루트 경로로 옮겨주세요.
+
+#### Android
+
+* CI에 Android target API level을 28로 설정함. (Android 9.0 'Pie')
+  * Target API level이 29 이상일 경우, 저장소 읽기/쓰기 권한과 관련한 문제가 발생함.
+
+### 업데이트 (v.1.2.1 -> v1.3.0)
+
+#### 공통
+
+* 셔터가 추가됐습니다!
+  * 공이 통과하기 전까지는, 셔터는 아무 일도 하지 않습니다.
+  * 공이 통과하고 나면, 셔터는 벽으로 바뀝니다.
+* Main scene에 BGM 추가
+* Tutorial 모드
+  * 셔터를 포함하는 맵 2개 추가
+* Editor 모드
+  * 맵에 셔터 추가 가능
+  * 폴더가 비어있을 경우, "Empty!" 텍스트 표시
+  * 긴 파일명과 관련한 버그 수정
+  * Open 및 Save UI에서 스크롤바와 관련한 버그 수정
+* Editor 내에서, Adventure 모드에서는 등장하지 않는 신규 맵(셔터를 포함하는 맵)을 플레이 가능함
+  * Android 유저 분들은, `GravitaMaze.zip`을 다운로드한 후 "내 파일" 앱을 사용해서 루트 경로(`Internal storage`)에 압축 해제해주세요.
+  * macOS 유저 분들은, `GravitaMaze.zip`을 다운로드한 후, 압축 해제해서 `Maps` 폴더를 `GravitaMaze.app`의 루트 경로로 옮겨주세요.
+* 지원 해상도 추가.
+  * 9:22 화면비 지원. (세로 화면)
+* Android, Windows, macOS에 대해 자동으로 빌드를 진행하도록 CI 추가.
+
+#### Android
+
+* CI에 Android target API level을 28로 설정함. (Android 9.0 'Pie')
+  * Target API level이 29 이상일 경우, 저장소 읽기/쓰기 권한과 관련한 문제가 발생함.
+
+### 업데이트 (v.1.1.0 -> v.1.2.1)
+
+#### 공통
+
+* Tutorial 모드
+  * 진행 사항이 표시됩니다.
+  * 일시 정지 및 계속 플레이 기능이 지원됩니다.
+  * 게임을 나가거나 클리어하면 결과창이 표시됩니다.
+* Adventure 모드
+  * 대규모 맵 밸런스 패치 적용
+    * Easy: 목숨 5개, 맵 10개, 난이도가 더 쉬워졌습니다!
+    * Normal: 목숨 5개, 맵 10개, 난이도가 약간 더 쉬워졌습니다.
+    * Hard: 목숨 7개, 맵 10개
+    * Insane: 목숨 10개, 맵 10개, 난이도가 더 어려워졌습니다!
+  * 남은 목숨과 진행 사항이 표시됩니다.
+  * 일시 정지 및 계속 플레이 기능이 지원됩니다.
+  * 게임을 나가거나 클리어하면 결과창이 표시됩니다.
+* Editor 내에서, Adventure 모드에서는 등장하지 않는 신규 맵을 플레이 가능함
+  * Android 유저 분들은, `GravitaMaze.zip`을 다운로드한 후 "내 파일" 앱을 사용해서 루트 경로(`Internal storage`)에 압축 해제해주세요.
+* 다양한 해상도 지원.
+  * 9:16, 9:18, 9:18.5, 9:19, 9:19.5, 9:20, 9:20.5, 9:21 화면비 지원. (세로 화면)
+  * 3:4 화면비 미지원.
+
+#### Android
+
+* Tutorial 및 Adventure 모드에서 뒤로가기 버튼을 누르면 일시정지 버튼이 적용됩니다.
+
+#### Windows
+
+* Tutorial 및 Adventure 모드에서 Enter 키를 누르면 다음 버튼이 적용됩니다.
+* Tutorial 및 Adventure 모드에서 Esc 키를 누르면 일시정지 버튼이 적용됩니다.
+
+#### macOS
+
+* Tutorial 및 Adventure 모드에서 Enter 키를 누르면 다음 버튼이 적용됩니다.
+* Tutorial 및 Adventure 모드에서 Esc 키를 누르면 일시정지 버튼이 적용됩니다.
+
+### 업데이트 (v.1.0.2 -> v.1.1.0)
+
+#### 공통
+
+* Adventure 모드를 플레이할 수 있습니다!
+  * Easy, Normal, Hard, Insane 레벨 제공.
+  * adventure 모드에서, 맵이 랜덤으로 회전하거나 반전됩니다.
+  * 5개의 목숨이 주어지지만, 아직 UI에서는 표시되지 않습니다.
+* 맵 파일(`.txt`)을 직접 수정해서 시간 제한을 30초 이상으로 늘리더라도, 시간 제한은 최대 30초로 고정됩니다.
+
+### 업데이트 (v.1.0.1 -> v.1.0.2)
+
+#### 공통
+
+* 시간 제한의 기본값이 10초에서 30초로 증가했습니다.
+* 여러 맵을 추가했습니다.
+
+#### Android
+
+* 맵의 저장 장소를 앱 내부 데이터에서 디바이스 내부 저장소로 변경했습니다.
+  * 나만의 맵을 공유하거나 다른 사람의 맵을 다운로드할 수 있습니다!
+  * 맵 파일은 `GravitaMaze/Maps`에 저장됩니다.
+
+</details>
+
+---
+
+## 플레이 방법
+
+### Android
+
+* [여기를 클릭!](https://github.com/salt26/gravita-maze/releases/tag/v1.4.1)
+* `GravitaMaze.v1.4.1.a.zip`을 Android 스마트폰에 다운로드해서 압축 해제한 후, `GravitaMaze.apk`를 실행해서 설치를 진행하세요.
+  * `출처를 알 수 없는 앱 설치` 창이 나오면, `무시하고 설치`를 선택하세요.
+  * Google Play Protect에서 `안전하지 않은 앱 차단됨` 창이 나오는 경우 ***확인 버튼을 누르지 말고*** `세부정보 더 보기 -> 무시하고 설치하기`를 선택하세요.
+  * `Google에 알 수 없는 앱 전송`과 관련한 메시지가 뜨는 경우가 있을 수도 있어요. 이 경우 무슨 옵션을 선택해도 상관 없어요.
+  * 브라우저에서 apk 파일이 다운로드되지 않는 경우, `설정 - 애플리케이션 - ... 아이콘 - 특별한 접근 - 출처를 알 수 없는 앱 설치`에서 해당 브라우저에 권한을 허용해주세요.
+  * 앱을 처음으로 실행하는 경우, 외부/내부 저장소 쓰기 권한을 허용해주셔야 해요.
+    * 해당 권한을 거부하는 경우, 앱에서 맵을 저장하거나 불러올 수 없어요.
+    * `다시 묻지 않음` 옵션을 선택한 경우, 애플리케이션 권한 설정에 들어가서 `GravitaMaze`에 해당 권한을 직접 허용해주셔야 해요.
+* `GravitaMaze.zip`을 다운로드한 후 "내 파일" 앱에서 루트 경로(`Internal storage`)에 압축 해제하시면 커스텀 맵을 즐길 수 있어요.
+  * 해당 맵은 Custom 모드에서 플레이 가능하며, Adventure 모드에서는 플레이할 수 없어요.
+* 4개의 "화살표" 버튼을 클릭해서 중력을 조작할 수 있어요.
+* 공이 죽는 경우, "재도전" 버튼을 터치해서 해당 맵에 재도전할 수 있어요.
+  * 공이 죽으면 시간이 멈춰요.
+  * 중력을 조작하면 시간이 다시 흘러요.
+* 제한 시간 안에 공을 미로에서 탈출시켜 보세요.
+  * 시간이 초과되면 목숨이 1개 깎여요.
+
+### Windows
+
+* [여기를 클릭!](https://github.com/salt26/gravita-maze/releases/tag/v1.4.1)
+* `GravitaMaze.v1.4.1.w.zip`을 다운로드한 후 압축 해제하세요.
+* `GravitaMaze.exe`를 실행하세요.
+* `GravitaMaze.zip`을 다운로드한 후 압축 해제하고, `Maps` 폴더를 `GravitaMaze.exe`의 루트 경로로 옮기면 커스텀 맵을 즐길 수 있어요.
+  * 해당 맵은 Custom 모드에서 플레이 가능하며, Adventure 모드에서는 플레이할 수 없어요.
+* 4개의 "화살표" 버튼을 클릭해서 중력을 조작할 수 있어요.
+* 공이 죽는 경우, "재도전" 버튼(또는 Space 키)을 눌러서 해당 맵에 재도전할 수 있어요.
+  * 공이 죽으면 시간이 멈춰요.
+  * 중력을 조작하면 시간이 다시 흘러요.
+* 제한 시간 안에 공을 미로에서 탈출시켜 보세요.
+  * 시간이 초과되면 목숨이 1개 깎여요.
+
+### macOS
+
+* [여기를 클릭!](https://github.com/salt26/gravita-maze/releases/tag/v1.4.1)
+* `GravitaMaze.v1.4.1.m.zip`을 다운로드한 후 압축 해제하세요.
+* `GravitaMaze.app`을 실행하세요.
+* `GravitaMaze.zip`을 다운로드한 후 압축 해제하고, `Maps` 폴더를 `GravitaMaze.app`의 루트 경로로 옮기면 커스텀 맵을 즐길 수 있어요.
+  * 해당 맵은 Custom 모드에서 플레이 가능하며, Adventure 모드에서는 플레이할 수 없어요.
+* 4개의 "화살표" 버튼을 클릭해서 중력을 조작할 수 있어요.
+* 공이 죽는 경우, "재도전" 버튼(또는 Space 키)을 눌러서 해당 맵에 재도전할 수 있어요.
+  * 공이 죽으면 시간이 멈춰요.
+  * 중력을 조작하면 시간이 다시 흘러요.
+* 제한 시간 안에 공을 미로에서 탈출시켜 보세요.
+  * 시간이 초과되면 목숨이 1개 깎여요.
+
+## 맵 에디터
+
+* 맵 에디터로 나만의 맵을 만들 수 있어요!
+
+## 플레이 모드
+
+* Tutorial 모드, 4개의 Adventure 모드, Custom 모드, Training 모드가 있어요!
+
+![Screenshot1](./Figures/Screenshot1.v1.3.1.png)
+
+![Screenshot2](./Figures/Screenshot2.v1.3.1.png)

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # GravitaMaze (중력 미로)
 
+[![en](https://img.shields.io/badge/lang-en-red.svg)](https://github.com/salt26/gravita-maze/blob/main/README.md)
+[![ko](https://img.shields.io/badge/lang-ko-blue.svg)](https://github.com/salt26/gravita-maze/blob/main/README.ko.md)
 [![Version badge](https://img.shields.io/badge/Version-1.4.1-purple.svg)](https://github.com/salt26/gravita-maze/releases/tag/v1.4.1)  
 [![Licence](https://img.shields.io/badge/License-MIT-green.svg)](./LICENSE)  
 ![Unity](https://img.shields.io/badge/unity-%23000000.svg?style=for-the-badge&logo=unity&logoColor=white)  
@@ -9,7 +11,7 @@
 
 * Puzzle game
   * Manipulate gravity to escape the ball!
-* English is fully available!
+* English and Korean are fully available!
 
 ### Download
 
@@ -76,7 +78,7 @@
   * Time pauses when the ball dies or the retry button is pressed. Time starts to go by again when you press any gravity manipulation buttons.
   * The timer UI changes color to pink while the time is paused. Its color turns purple while the time goes by.
   * When a ball escapes, it is shown an animation that moves slowly by gravity.
-* Add a new BGM for the game play scenes(Tutorial, Adventure and Test phase in Editor).
+* Add a new BGM for the game play scenes (Tutorial, Adventure and Test phase in Editor).
 * In Adventure mode,
   * Huge scale of map balance patch is done.
     * Easy: 5 maps are replaced, and the time limit of a map is changed.
@@ -86,7 +88,7 @@
   * Maps with shutters can also appear in adventure mode.
 * You can enjoy some new maps (including shutters) in the editor that are not in adventure mode.
   * If you are using Android, please download `GravitaMaze.zip` and unzip it in root directory(`Internal storage`) using "My Files" app.
-  * If you are using macOS, please  download `GravitaMaze.zip`, unzip it, and move `Maps` folder to the root directory of `GravitaMaze.app`.
+  * If you are using macOS, please download `GravitaMaze.zip`, unzip it, and move `Maps` folder to the root directory of `GravitaMaze.app`.
 
 #### Android
 
@@ -189,13 +191,16 @@
 ### Android
 
 * Click [here](https://github.com/salt26/gravita-maze/releases/tag/v1.4.1)!
-* Download `GravitaMaze.v1.4.1.a.zip` on your Android cell phone, unzip it, and execute `GravitaMaze.apk` to install it.
-  * You may need to allow "Install unknown apps" (in "Settings" - "Apps" - "..." - "Special access" - "Install unknown apps")
+* Download `GravitaMaze.v1.4.1.a.zip` on your Android phone, unzip it, and execute `GravitaMaze.apk` to install it.
+  * When the `Install unknown app` message appears, choose `Ignore and install`
+  * If Google Play Protect shows `Blocked by Play Protect` message, ***DO NOT CLICK OK MESSAGE***. Instead, click `Details -> Install anyway (unsafe)`.
+  * `Send app for scanning?` message might appear. You can choose whatever option you want.
+  * If you can't download apk file in a browser, grant `Install Unknown Apps` permission to that browser in `Settings - Apps - ... icon - Special Access - Install Unknown Apps`.
   * When you run the app for the first time, you need to allow permission to write to external/internal storage.
     * If you deny permission, the app will not be able to create or load maps.
-    * If you checked the “Do not ask me again” option, you must go into the application permission settings and manually turn on the permission for `GravitaMaze`.
+    * If you checked the `Do not ask me again` option, you must go into the application permission settings and manually turn on the permission for `GravitaMaze`.
 * You can download `GravitaMaze.zip` and unzip it in root directory(`Internal storage`) using "My Files" app to enjoy the custom maps.
-  * These maps are playable in the editor, not in Adventure mode.
+  * These maps are playable in Custom mode, not in Adventure mode.
 * The gravity can be manipulated by touching the four "arrow" buttons.
 * Whenever the ball dies, you can touch "retry" button to retry the map.
   * Time stops while the ball is dead.
@@ -209,8 +214,9 @@
 * Download `GravitaMaze.v1.4.1.w.zip` and unzip it.
 * Execute `GravitaMaze.exe`.
 * You can download `GravitaMaze.zip` and unzip, and move the `Maps` folder to the root directory of `GravitaMaze.exe` to enjoy the custom maps.
+  * These maps are playable in Custom mode, not in Adventure mode.
 * The gravity can be manipulated by pressing the four "arrow" buttons.
-* Whenever the ball dies, you can press "retry"(space) button to retry the map.
+* Whenever the ball dies, you can press "retry" button (or Space key) to retry the map.
   * Time stops while the ball is dead.
   * Time passes after you manipulate gravity.
 * Escape the ball before the time limit is over.
@@ -222,8 +228,9 @@
 * Download `GravitaMaze.v1.4.1.m.zip` and unzip it.
 * Execute `GravitaMaze.app`.
 * You can download `GravitaMaze.zip`, unzip it, and move the `Maps` folder to the root directory of `GravitaMaze.app` to enjoy the custom maps.
+  * These maps are playable in Custom mode, not in Adventure mode.
 * The gravity can be manipulated by pressing the four "arrow" buttons.
-* Whenever the ball dies, you can press "retry"(space) button to retry the map.
+* Whenever the ball dies, you can press "retry" button (or Space key) to retry the map.
   * Time stops while the ball is dead.
   * Time passes after you manipulate gravity.
 * Escape the ball before the time limit is over.

--- a/README.md
+++ b/README.md
@@ -1,32 +1,39 @@
 # GravitaMaze (중력 미로)
+
 [![Version badge](https://img.shields.io/badge/Version-1.4.1-purple.svg)](https://github.com/salt26/gravita-maze/releases/tag/v1.4.1)  
 [![Licence](https://img.shields.io/badge/License-MIT-green.svg)](./LICENSE)  
 ![Unity](https://img.shields.io/badge/unity-%23000000.svg?style=for-the-badge&logo=unity&logoColor=white)  
 ![GitHub Actions](https://img.shields.io/badge/github%20actions-%232671E5.svg?style=for-the-badge&logo=githubactions&logoColor=white)
 
 ## Introduction
+
 * Puzzle game
   * Manipulate gravity to escape the ball!
 * English is fully available!
 
 ### Download
+
 #### [v1.4.1 for Android, Windows, and macOS](https://github.com/salt26/gravita-maze/releases/tag/v1.4.1)
 
 <details>
 <summary>Click here to expand or collapse the old update logs!</summary>
- 
+
 ### Updates (v1.3.1 -> v1.4.0)
+
 #### Sound
+
 * Add various sound effects
 * Add background music for editor scene
 
 #### Considerations for First-time Users
+
 * Add a first-time user scene that allows users to start the tutorial immediately after installing the app.
   * Skip is also available.
 * Provide a detailed tutorial tooltip.
 * Minor changes in tutorial maps
 
 #### Add New Modes
+
 * Add Custom mode
   * You can play by selecting the map you want.
   * From now, you don't need to enter editor mode to play custom maps.
@@ -37,6 +44,7 @@
 * Add credit scene
 
 #### Giving a Sense of Accomplishment and Motivation
+
 * Reorganize result UI of Tutorial and Adventure mode with some animations and SFXs.
 * Add star system
   * If you clear the Tutorial, you will receive three stars.
@@ -50,6 +58,7 @@
 * Add new maps and adjust map balance
 
 #### Improving convenience and user experience
+
 * Expand the size of the four types of gravity manipulation buttons.
 * All the letters of iron were changed to bright colors overall.
 * In the mode selection scene and the adventure level selection scene, maps are reorganized so that there is no need to press the retry button.
@@ -60,12 +69,14 @@
 * Change the image and add animation of the portal.
 
 ### Updates (v1.3.0 -> v1.3.1)
+
 #### Common
+
 * In any game play mode,
   * Time pauses when the ball dies or the retry button is pressed. Time starts to go by again when you press any gravity manipulation buttons.
   * The timer UI changes color to pink while the time is paused. Its color turns purple while the time goes by.
   * When a ball escapes, it is shown an animation that moves slowly by gravity.
-* Add a new BGM for the game play scenes(Tutorial, Adventure and Test phase in Editor). 
+* Add a new BGM for the game play scenes(Tutorial, Adventure and Test phase in Editor).
 * In Adventure mode,
   * Huge scale of map balance patch is done.
     * Easy: 5 maps are replaced, and the time limit of a map is changed.
@@ -78,15 +89,18 @@
   * If you are using macOS, please  download `GravitaMaze.zip`, unzip it, and move `Maps` folder to the root directory of `GravitaMaze.app`.
 
 #### Android
+
 * The continuous integration(CI) targets Android API level to 28. (Android 9.0 'Pie')
   * This is because there are issues related to storage read/write permission when the target API level is 29 or higher.
 
 ### Updates (v.1.2.1 -> v1.3.0)
+
 #### Common
+
 * The Shutter has added!
   * Until the ball passes, the shutter is the same as no wall.
   * Once a ball passes, the shutter is treated as a wall.
-* Add a BGM for the main scene. 
+* Add a BGM for the main scene.
 * In Tutorial mode,
   * Two maps are added, including shutters.
 * In Editor mode,
@@ -102,11 +116,14 @@
 * The continuous integration(CI) was added to automatically build for Android, Windows and macOS.
 
 #### Android
+
 * The target API level is set to 28. (Android 9.0 'Pie')
   * This is because there are issues related to storage read/write permission when the target API level is 29 or higher.
 
 ### Updates (v.1.1.0 -> v.1.2.1)
+
 #### Common
+
 * In Tutorial mode,
   * The progress is displayed.
   * You can pause and resume the game.
@@ -127,18 +144,23 @@
   * 3:4 is not supported.
 
 #### Android
+
 * You can press the Back key to press the Pause button in Tutorial and Adventure mode.
 
 #### Windows
+
 * You can press the Enter key to press the Next button in Tutorial and Adventure mode.
 * You can press the Esc key to press the Pause button in Tutorial and Adventure mode.
 
 #### macOS
+
 * You can press the Enter key to press the Next button in Tutorial and Adventure mode.
 * You can press the Esc key to press the Pause button in Tutorial and Adventure mode.
 
 ### Updates (v.1.0.2 -> v.1.1.0)
+
 #### Common
+
 * Adventure mode is now playable!
   * There are Easy, Normal, Hard, and Insane levels.
   * In adventure mode, the map is randomly rotated or flipped.
@@ -146,20 +168,26 @@
 * Even if you modify the map file(`.txt`) directly to increase the time limit to more than 30 seconds, the maximum time limit is set to 30 seconds.
 
 ### Updates (v.1.0.1 -> v.1.0.2)
+
 #### Common
+
 * The default value for the time limit has increased from 10 seconds to 30 seconds.
 * Several maps have been added.
 
 #### Android
+
 * Maps can now be saved on internal storage rather than on the app's internal data.
   * You can share your own map or download other's map!
   * The map files are saved in `GravitaMaze/Maps`.
+
 </details>
 
 ---
 
 ## How to Play
-#### Android
+
+### Android
+
 * Click [here](https://github.com/salt26/gravita-maze/releases/tag/v1.4.1)!
 * Download `GravitaMaze.v1.4.1.a.zip` on your Android cell phone, unzip it, and execute `GravitaMaze.apk` to install it.
   * You may need to allow "Install unknown apps" (in "Settings" - "Apps" - "..." - "Special access" - "Install unknown apps")
@@ -175,7 +203,8 @@
 * Escape the ball before the time limit is over.
   * If you time out, you lose one life.
 
-#### Windows
+### Windows
+
 * Click [here](https://github.com/salt26/gravita-maze/releases/tag/v1.4.1)!
 * Download `GravitaMaze.v1.4.1.w.zip` and unzip it.
 * Execute `GravitaMaze.exe`.
@@ -187,7 +216,8 @@
 * Escape the ball before the time limit is over.
   * If you time out, you lose one life.
 
-#### macOS
+### macOS
+
 * Click [here](https://github.com/salt26/gravita-maze/releases/tag/v1.4.1)!
 * Download `GravitaMaze.v1.4.1.m.zip` and unzip it.
 * Execute `GravitaMaze.app`.
@@ -199,10 +229,12 @@
 * Escape the ball before the time limit is over.
   * If you time out, you lose one life.
 
-### Map Editor
+## Map Editor
+
 * You can use the map editor to make your own custom maps!
 
-### Play Modes
+## Play Modes
+
 * There are a Tutorial mode, four Adventure modes, Custom modes and Training mode.
 
 ![Screenshot1](./Figures/Screenshot1.v1.3.1.png)


### PR DESCRIPTION
- Add `shields.io` style links at README header for multi language support
  - Inspired by [Multilanguage README Pattern](https://github.com/jonatasemidio/multilanguage-readme-pattern)
- Create `README.ko.md`, a Korean version of README
- Minor updates on README
